### PR TITLE
Do not wait for idle when wait=False

### DIFF
--- a/mirobot/base_mirobot.py
+++ b/mirobot/base_mirobot.py
@@ -221,7 +221,7 @@ class BaseMirobot(AbstractContextManager):
                                       disable_debug=disable_debug,
                                       terminator=os.linesep,
                                       wait=(wait or (wait is None and self.wait)),
-                                      wait_idle=wait_idle)
+                                      wait_idle=((wait or (wait is None and self.wait)) and wait_idle))
 
             return output
 


### PR DESCRIPTION
When wait=False, the robot still waits for completion on goto commands due to wait_idle. This change disables wait_idle if wait=False.